### PR TITLE
fix: Ensure password always contains required character types

### DIFF
--- a/PowerShell/Functions/New-GeneratedPassword.ps1
+++ b/PowerShell/Functions/New-GeneratedPassword.ps1
@@ -1,43 +1,43 @@
 function New-GeneratedPassword {
-<#
-.SYNOPSIS
-    This will generate a simple random password like "rvsZxx0lr" and optionally include numbers and/or special characters
-#>
+    <#
+    .SYNOPSIS
+        This will generate a simple random password like "f6Tk9aqatc$x" and optionally include numbers and/or special characters
+    #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $false)]
         $MinimumLength = 12,
-
+    
         [Parameter(Mandatory = $false)]
         $MaximumLength = 16,
-
+    
         [Parameter(Mandatory = $false)]
         $MinimumUpperCaseLetters = 1,
-
+    
         [Parameter(Mandatory = $false)]
         $MaximumUpperCaseLetters = 2,
-
+    
         [Parameter(Mandatory = $false)]
-        $MinimumDigits,
-
+        $MinimumDigits = 2,
+    
         [Parameter(Mandatory = $false)]
-        $MaximumDigits,
-                
+        $MaximumDigits = 3,
+                    
         [Parameter(Mandatory = $false)]
-        $MinimumSpecialChars,
-
+        $MinimumSpecialChars = 1,
+    
         [Parameter(Mandatory = $false)]
-        $MaximumSpecialChars,
-        
+        $MaximumSpecialChars = 2,
+            
         [Parameter(Mandatory = $false)]
         $AllowedLowerCaseLetters = 'abcdefghjkmnpqrstuvwxyz',
-
+    
         [Parameter(Mandatory = $false)]
         $AllowedUpperCaseLetters = 'ABCDEFGHJKMNPQRSTUVWXYZ',
-        
+            
         [Parameter(Mandatory = $false)]
         $AllowedDigits = '23456789',
-
+    
         [Parameter(Mandatory = $false)]
         $AllowedSpecialChars = '!#$@*?'
     )
@@ -45,7 +45,7 @@ function New-GeneratedPassword {
     $upperCaseLetters = $null
     $digits = $null
     $specialChars = $null
-
+    
     # Total length of random password
     if ($MinimumLength -ne $MaximumLength) {
         $totalLength = Get-Random -Minimum $MinimumLength -Maximum $MaximumLength
@@ -53,7 +53,7 @@ function New-GeneratedPassword {
     else {
         $totalLength = $MaximumLength
     }
-
+    
     <#--------- Upper case letters ---------#>
     # Total length of allowed upper case letters
     if ($MinimumUpperCaseLetters -and $MaximumUpperCaseLetters) {
@@ -68,13 +68,13 @@ function New-GeneratedPassword {
     else {
         $amountOfUpperCaseLetters = 0
     }
-
+    
     # Get random upper case letters
     if ($amountOfUpperCaseLetters -gt 0) {
         $random = 1..$amountOfUpperCaseLetters | ForEach-Object { Get-Random -Maximum $AllowedUpperCaseLetters.Length }
         $upperCaseLetters = ([String]$AllowedUpperCaseLetters[$random]).replace(" ", "")
     }
-
+    
     <#--------- Digits ---------#>
     # Total length of allowed digits
     if ($MinimumDigits -and $MaximumDigits) {
@@ -89,14 +89,14 @@ function New-GeneratedPassword {
     else {
         $amountOfDigits = 0
     }
-
+    
     # Get random digits
     if ($amountOfDigits -gt 0) {
         $random = 1..$amountOfDigits | ForEach-Object { Get-Random -Maximum $AllowedDigits.Length }
         $digits = ([String]$AllowedDigits[$random]).replace(" ", "")
     }
-
-
+    
+    
     <#--------- Special Characters ---------#>
     # Total length of allowed special characters
     if ($MinimumSpecialChars -and $MaximumSpecialChars) {
@@ -111,41 +111,67 @@ function New-GeneratedPassword {
     else {
         $amountOfSpecialChars = 0
     }
-
+    
     # Get random special chars
     if ($amountOfSpecialChars -gt 0) {
         $random = 1..$amountOfSpecialChars | ForEach-Object { Get-Random -Maximum $AllowedSpecialChars.Length }
         $specialChars = ([String]$AllowedSpecialChars[$random]).replace(" ", "")
     }
-
+    
     <#--------- Lower case letters ---------#>
     # Get random lower case letters
     $amountOfLowerCaseLetters = ($totalLength - $amountOfUpperCaseLetters - $amountOfDigits - $amountOfSpecialChars)
     $random = 1..$amountOfLowerCaseLetters | ForEach-Object { Get-Random -Maximum $AllowedLowerCaseLetters.Length }
     $lowerCaseLetters = ([String]$AllowedLowerCaseLetters[$random]).replace(" ", "")
-
-    # Join all generated password charactesr to one string
+    
+    # Join all generated password characters into one string
     $passwordCharacters = ($lowerCaseLetters + $upperCaseLetters + $digits + $specialChars).replace(" ", "")
 
-    # Make sure password doesn't start with a digit
-    $randomPassword = "$($lowerCaseLetters.ToCharArray() | Get-Random -Count 1)"
+    # Define the first character
+    $startingCharacter = "$($lowerCaseLetters.ToCharArray() | Get-Random -Count 1)"
+
+    # Remove the character already in $randomPassword from $passwordCharacters once
+    $passwordCharacters = $passwordCharacters.Remove($passwordCharacters.IndexOf($startingCharacter), 1)
 
     # Scramble password characters
-    $characterArray = $passwordCharacters.ToCharArray()   
-    $scrambledStringArray = $characterArray | Get-Random -Count ($characterArray.Length - 1)
-    $randomPassword += -join $scrambledStringArray
-    return $randomPassword
-}
+    $characterArray = $passwordCharacters.ToCharArray() | Get-Random -Count ($passwordCharacters.Length)
 
-try {
-    $Password = New-GeneratedPassword -MinimumLength 12 -MaximumLength 16 -MinimumDigits 1
+    # Generate the password
+    # Set the starting character
+    $randomPassword = $startingCharacter
+    # Set the remain characters
+    $scrambledStringArray = $characterArray
+    $randomPassword += -join $scrambledStringArray
+
+    # Output the final password
+    return $randomPassword 
+}
     
+try {
+    $params = @{
+        MinimumLength           = 12
+        MaximumLength           = 12
+        MinimumUpperCaseLetters = 1
+        MaximumUpperCaseLetters = 2
+        MinimumDigits           = 2
+        MaximumDigits           = 3
+        MinimumSpecialChars     = 1
+        MaximumSpecialChars     = 2
+        AllowedUpperCaseLetters = 'ABCDEFGHJKMNPQRSTUVWXYZ'
+        AllowedLowerCaseLetters = 'abcdefghjkmnpqrstuvwxyz'
+        AllowedDigits           = '23456789'
+        AllowedSpecialChars     = '!#$@*?'
+    }
+    
+    $Password = New-GeneratedPassword @params
+
     $returnObject = @{
         password = $Password
     }
     Write-output $returnObject
-
+    
     Write-information "Successfully generated random password"
-} catch {
+}
+catch {
     Write-error "Error generating random password. Error: $($_.Exception.Message)"
 }


### PR DESCRIPTION
Fixed password generation so all required uppercase letters, digits, and special characters are always present.

This was caused by logic that could randomly drop a mandatory character type during scrambling.